### PR TITLE
Remove Params from Handler and use ctx.UserValue instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 FastHttpRouter is forked from [httprouter](https://github.com/julienschmidt/httprouter) which is a lightweight high performance HTTP request router
 (also called *multiplexer* or just *mux* for short) for [fasthttp](https://github.com/valyala/fasthttp).
 
-In contrast to the [RequestHandler](https://godoc.org/github.com/valyala/fasthttp#RequestHandler) functions of valyala's `fasthttp` package, this router supports variables in the routing pattern and matches against the request method. It also scales better.
+In addition to the [RequestHandler](https://godoc.org/github.com/valyala/fasthttp#RequestHandler) functions of valyala's `fasthttp` package, this router supports fetching `param` variables into `RequestCtx.UserVales` and matching against the request method. It also scales better.
 
 The router is optimized for high performance and a small memory footprint. It scales well even with very long paths and a large number of routes. A compressing dynamic trie (radix tree) structure is used for efficient matching.
 
@@ -79,12 +79,12 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-func Index(ctx *fasthttp.RequestCtx, _ fasthttprouter.Params) {
+func Index(ctx *fasthttp.RequestCtx) {
 	fmt.Fprint(ctx, "Welcome!\n")
 }
 
-func Hello(ctx *fasthttp.RequestCtx, ps fasthttprouter.Params) {
-	fmt.Fprintf(ctx, "hello, %s!\n", ps.ByName("name"))
+func Hello(ctx *fasthttp.RequestCtx) {
+	fmt.Fprintf(ctx, "hello, %s!\n", ctx.UserValue("name"))
 }
 
 func main() {
@@ -98,7 +98,7 @@ func main() {
 
 ### Named parameters
 
-As you can see, `:name` is a *named parameter*. The values are accessible via `httprouter.Params`, which is just a slice of `httprouter.Param`s. You can get the value of a parameter either by its index in the slice, or by using the `ByName(name)` method: `:name` can be retrived by `ByName("name")`.
+As you can see, `:name` is a *named parameter*. The values are accessible via `RequestCtx.UserValues`. You can get the value of a parameter by using the `ctx.UserValue("name")`.
 
 Named parameters only match a single path segment:
 
@@ -174,9 +174,9 @@ Just try it out for yourself, the usage of FastHttpRouter is very straightforwar
 
 ## Where can I find Middleware *X*?
 
-This package just provides a very efficient request router with a few extra features. The router is just a [`http.Handler`][http.Handler], you can chain any http.Handler compatible middleware before the router, for example the [Gorilla handlers](http://www.gorillatoolkit.org/pkg/handlers). Or you could [just write your own](https://justinas.org/writing-http-middleware-in-go/), it's very easy!
+This package just provides a very efficient request router with a few extra features. The router is just a [`fasthttp.RequestHandler`](https://godoc.org/github.com/valyala/fasthttp#RequestHandler), you can chain any fasthttp.RequestHandler compatible middleware before the router. Or you could [just write your own](https://justinas.org/writing-http-middleware-in-go/), it's very easy!
 
-Alternatively, you could try [a web framework based on HttpRouter](#web-frameworks-based-on-httprouter).
+Alternatively, you could try a web framework based on FastHttpRouter - Coming soon.
 
 ### Multi-domain / Sub-domains
 
@@ -237,7 +237,7 @@ import (
 var basicAuthPrefix = []byte("Basic ")
 
 func BasicAuth(h fasthttprouter.Handle, user, pass []byte) fasthttprouter.Handle {
-	return fasthttprouter.Handle(func(ctx *fasthttp.RequestCtx, ps fasthttprouter.Params) {
+	return fasthttprouter.Handle(func(ctx *fasthttp.RequestCtx) {
 		// Get the Basic Authentication credentials
 		auth := ctx.Request.Header.Peek("Authorization")
 		if bytes.HasPrefix(auth, basicAuthPrefix) {
@@ -249,7 +249,7 @@ func BasicAuth(h fasthttprouter.Handle, user, pass []byte) fasthttprouter.Handle
 					bytes.Equal(pair[0], user) &&
 					bytes.Equal(pair[1], pass) {
 					// Delegate request to the given handle
-					h(ctx, ps)
+					h(ctx)
 					return
 				}
 			}
@@ -261,11 +261,11 @@ func BasicAuth(h fasthttprouter.Handle, user, pass []byte) fasthttprouter.Handle
 	})
 }
 
-func Index(ctx *fasthttp.RequestCtx, _ fasthttprouter.Params) {
+func Index(ctx *fasthttp.RequestCtx) {
 	fmt.Fprint(ctx, "Not protected!\n")
 }
 
-func Protected(ctx *fasthttp.RequestCtx, _ fasthttprouter.Params) {
+func Protected(ctx *fasthttp.RequestCtx) {
 	fmt.Fprint(ctx, "Protected!\n")
 }
 

--- a/examples/auth.go
+++ b/examples/auth.go
@@ -14,7 +14,7 @@ var basicAuthPrefix = []byte("Basic ")
 
 // BasicAuth is the basic auth handler
 func BasicAuth(h fasthttprouter.Handle, user, pass []byte) fasthttprouter.Handle {
-	return fasthttprouter.Handle(func(ctx *fasthttp.RequestCtx, ps fasthttprouter.Params) {
+	return fasthttprouter.Handle(func(ctx *fasthttp.RequestCtx) {
 		// Get the Basic Authentication credentials
 		auth := ctx.Request.Header.Peek("Authorization")
 		if bytes.HasPrefix(auth, basicAuthPrefix) {
@@ -26,7 +26,7 @@ func BasicAuth(h fasthttprouter.Handle, user, pass []byte) fasthttprouter.Handle
 					bytes.Equal(pair[0], user) &&
 					bytes.Equal(pair[1], pass) {
 					// Delegate request to the given handle
-					h(ctx, ps)
+					h(ctx)
 					return
 				}
 			}
@@ -39,12 +39,12 @@ func BasicAuth(h fasthttprouter.Handle, user, pass []byte) fasthttprouter.Handle
 }
 
 // Index is the index handler
-func Index(ctx *fasthttp.RequestCtx, _ fasthttprouter.Params) {
+func Index(ctx *fasthttp.RequestCtx) {
 	fmt.Fprint(ctx, "Not protected!\n")
 }
 
 // Protected is the Protected handler
-func Protected(ctx *fasthttp.RequestCtx, _ fasthttprouter.Params) {
+func Protected(ctx *fasthttp.RequestCtx) {
 	fmt.Fprint(ctx, "Protected!\n")
 }
 

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -9,18 +9,18 @@ import (
 )
 
 // Index is the index handler
-func Index(ctx *fasthttp.RequestCtx, _ fasthttprouter.Params) {
+func Index(ctx *fasthttp.RequestCtx) {
 	fmt.Fprint(ctx, "Welcome!\n")
 }
 
 // Hello is the Hello handler
-func Hello(ctx *fasthttp.RequestCtx, ps fasthttprouter.Params) {
-	fmt.Fprintf(ctx, "hello, %s!\n", ps.ByName("name"))
+func Hello(ctx *fasthttp.RequestCtx) {
+	fmt.Fprintf(ctx, "hello, %s!\n", ctx.UserValue("name"))
 }
 
 // MultiParams is the multi params handler
-func MultiParams(ctx *fasthttp.RequestCtx, ps fasthttprouter.Params) {
-	fmt.Fprintf(ctx, "hi, %s, %s!\n", ps.ByName("name"), ps.ByName("word"))
+func MultiParams(ctx *fasthttp.RequestCtx) {
+	fmt.Fprintf(ctx, "hi, %s, %s!\n", ctx.UserValue("name"), ctx.UserValue("word"))
 }
 
 func main() {

--- a/examples/hosts.go
+++ b/examples/hosts.go
@@ -9,13 +9,13 @@ import (
 )
 
 // Index is the index handler
-func Index(ctx *fasthttp.RequestCtx, _ fasthttprouter.Params) {
+func Index(ctx *fasthttp.RequestCtx) {
 	fmt.Fprint(ctx, "Welcome!\n")
 }
 
 // Hello is the Hello handler
-func Hello(ctx *fasthttp.RequestCtx, ps fasthttprouter.Params) {
-	fmt.Fprintf(ctx, "hello, %s!\n", ps.ByName("name"))
+func Hello(ctx *fasthttp.RequestCtx) {
+	fmt.Fprintf(ctx, "hello, %s!\n", ctx.UserValue("name"))
 }
 
 // HostSwitch is the host-handler map

--- a/router.go
+++ b/router.go
@@ -16,12 +16,12 @@
 //     "github.com/valyala/fasthttp"
 // )
 
-// func Index(ctx *fasthttp.RequestCtx, _ fasthttprouter.Params) {
+// func Index(ctx *fasthttp.RequestCtx) {
 //     fmt.Fprint(ctx, "Welcome!\n")
 // }
 
-// func Hello(ctx *fasthttp.RequestCtx, ps fasthttprouter.Params) {
-//     fmt.Fprintf(ctx, "hello, %s!\n", ps.ByName("name"))
+// func Hello(ctx *fasthttp.RequestCtx) {
+//     fmt.Fprintf(ctx, "hello, %s!\n", ctx.UserValue("name"))
 // }
 
 // func main() {
@@ -65,16 +65,11 @@
 //   /files/templates/article.html       match: filepath="/templates/article.html"
 //   /files                              no match, but the router would redirect
 //
-// The value of parameters is saved as a slice of the Param struct, consisting
-// each of a key and a value. The slice is passed to the Handle func as a third
-// parameter.
-// There are two ways to retrieve the value of a parameter:
-//  // by the name of the parameter
-//  user := ps.ByName("user") // defined by :user or *user
+// The value of parameters is inside ctx.UserValue
+// To retrieve the value of a parameter:
+//  // use the name of the parameter
+//  user := ps.UserValue("user")
 //
-//  // by the index of the parameter. This way you can also get the name (key)
-//  thirdKey   := ps[2].Key   // the name of the 3rd parameter
-//  thirdValue := ps[2].Value // the value of the 3rd parameter
 
 package fasthttprouter
 

--- a/router.go
+++ b/router.go
@@ -88,33 +88,6 @@ var (
 	defaultContentType = []byte("text/plain; charset=utf-8")
 )
 
-// Handle is a function that can be registered to a route to handle HTTP
-// requests. Like http.HandlerFunc, but has a third parameter for the values of
-// wildcards (variables).
-type Handle func(*fasthttp.RequestCtx, Params)
-
-// Param is a single URL parameter, consisting of a key and a value.
-type Param struct {
-	Key   string
-	Value string
-}
-
-// Params is a Param-slice, as returned by the router.
-// The slice is ordered, the first URL parameter is also the first slice value.
-// It is therefore safe to read values by the index.
-type Params []Param
-
-// ByName returns the value of the first Param which key matches the given name.
-// If no matching Param is found, an empty string is returned.
-func (ps Params) ByName(name string) string {
-	for i := range ps {
-		if ps[i].Key == name {
-			return ps[i].Value
-		}
-	}
-	return ""
-}
-
 // Router is a http.Handler which can be used to dispatch requests to different
 // handler functions via configurable routes
 type Router struct {
@@ -181,37 +154,37 @@ func New() *Router {
 }
 
 // GET is a shortcut for router.Handle("GET", path, handle)
-func (r *Router) GET(path string, handle Handle) {
+func (r *Router) GET(path string, handle fasthttp.RequestHandler) {
 	r.Handle("GET", path, handle)
 }
 
 // HEAD is a shortcut for router.Handle("HEAD", path, handle)
-func (r *Router) HEAD(path string, handle Handle) {
+func (r *Router) HEAD(path string, handle fasthttp.RequestHandler) {
 	r.Handle("HEAD", path, handle)
 }
 
 // OPTIONS is a shortcut for router.Handle("OPTIONS", path, handle)
-func (r *Router) OPTIONS(path string, handle Handle) {
+func (r *Router) OPTIONS(path string, handle fasthttp.RequestHandler) {
 	r.Handle("OPTIONS", path, handle)
 }
 
 // POST is a shortcut for router.Handle("POST", path, handle)
-func (r *Router) POST(path string, handle Handle) {
+func (r *Router) POST(path string, handle fasthttp.RequestHandler) {
 	r.Handle("POST", path, handle)
 }
 
 // PUT is a shortcut for router.Handle("PUT", path, handle)
-func (r *Router) PUT(path string, handle Handle) {
+func (r *Router) PUT(path string, handle fasthttp.RequestHandler) {
 	r.Handle("PUT", path, handle)
 }
 
 // PATCH is a shortcut for router.Handle("PATCH", path, handle)
-func (r *Router) PATCH(path string, handle Handle) {
+func (r *Router) PATCH(path string, handle fasthttp.RequestHandler) {
 	r.Handle("PATCH", path, handle)
 }
 
 // DELETE is a shortcut for router.Handle("DELETE", path, handle)
-func (r *Router) DELETE(path string, handle Handle) {
+func (r *Router) DELETE(path string, handle fasthttp.RequestHandler) {
 	r.Handle("DELETE", path, handle)
 }
 
@@ -223,7 +196,7 @@ func (r *Router) DELETE(path string, handle Handle) {
 // This function is intended for bulk loading and to allow the usage of less
 // frequently used, non-standardized or custom methods (e.g. for internal
 // communication with a proxy).
-func (r *Router) Handle(method, path string, handle Handle) {
+func (r *Router) Handle(method, path string, handle fasthttp.RequestHandler) {
 	if path[0] != '/' {
 		panic("path must begin with '/' in path '" + path + "'")
 	}
@@ -257,7 +230,7 @@ func (r *Router) ServeFiles(path string, rootPath string) {
 
 	fileHandler := fasthttp.FSHandler(rootPath, strings.Count(prefix, "/"))
 
-	r.GET(path, func(ctx *fasthttp.RequestCtx, _ Params) {
+	r.GET(path, func(ctx *fasthttp.RequestCtx) {
 		fileHandler(ctx)
 	})
 }
@@ -273,9 +246,9 @@ func (r *Router) recv(ctx *fasthttp.RequestCtx) {
 // If the path was found, it returns the handle function and the path parameter
 // values. Otherwise the third return value indicates whether a redirection to
 // the same path with an extra / without the trailing slash should be performed.
-func (r *Router) Lookup(method, path string) (Handle, Params, bool) {
+func (r *Router) Lookup(method, path string) (fasthttp.RequestHandler, bool) {
 	if root := r.trees[method]; root != nil {
-		return root.getValue(path)
+		return root.getValue(path, nil)
 	}
 	return nil, nil, false
 }
@@ -301,7 +274,7 @@ func (r *Router) allowed(path, reqMethod string) (allow string) {
 				continue
 			}
 
-			handle, _, _ := r.trees[method].getValue(path)
+			handle, _ := r.trees[method].getValue(path, nil)
 			if handle != nil {
 				// add request method to list of allowed methods
 				if len(allow) == 0 {
@@ -327,8 +300,8 @@ func (r *Router) Handler(ctx *fasthttp.RequestCtx) {
 	path := string(ctx.Path())
 	method := string(ctx.Method())
 	if root := r.trees[method]; root != nil {
-		if f, ps, tsr := root.getValue(path); f != nil {
-			f(ctx, ps)
+		if f, tsr := root.getValue(path, ctx); f != nil {
+			f(ctx)
 			return
 		} else if method != "CONNECT" && path != "/" {
 			code := 301 // Permanent redirect, request with GET method

--- a/router.go
+++ b/router.go
@@ -246,11 +246,11 @@ func (r *Router) recv(ctx *fasthttp.RequestCtx) {
 // If the path was found, it returns the handle function and the path parameter
 // values. Otherwise the third return value indicates whether a redirection to
 // the same path with an extra / without the trailing slash should be performed.
-func (r *Router) Lookup(method, path string) (fasthttp.RequestHandler, bool) {
+func (r *Router) Lookup(method, path string, ctx *fasthttp.RequestCtx) (fasthttp.RequestHandler, bool) {
 	if root := r.trees[method]; root != nil {
-		return root.getValue(path, nil)
+		return root.getValue(path, ctx)
 	}
-	return nil, nil, false
+	return nil, false
 }
 
 func (r *Router) allowed(path, reqMethod string) (allow string) {

--- a/router_test.go
+++ b/router_test.go
@@ -792,7 +792,7 @@ func TestRouterLookup(t *testing.T) {
 			t.Fatal("Routing failed!")
 		}
 	}
-	if ctx.UserValue("user") != "gopher" {
+	if ctx.UserValue("name") != "gopher" {
 		t.Error("Param not set!")
 	}
 

--- a/router_test.go
+++ b/router_test.go
@@ -13,38 +13,22 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/valyala/fasthttp"
 )
 
-func TestParams(t *testing.T) {
-	ps := Params{
-		Param{"param1", "value1"},
-		Param{"param2", "value2"},
-		Param{"param3", "value3"},
-	}
-	for i := range ps {
-		if val := ps.ByName(ps[i].Key); val != ps[i].Value {
-			t.Errorf("Wrong value for %s: Got %s; Want %s", ps[i].Key, val, ps[i].Value)
-		}
-	}
-	if val := ps.ByName("noKey"); val != "" {
-		t.Errorf("Expected empty string for not found key; got: %s", val)
-	}
-}
-
 func TestRouter(t *testing.T) {
 	router := New()
 
 	routed := false
-	router.Handle("GET", "/user/:name", func(ctx *fasthttp.RequestCtx, ps Params) {
+	router.Handle("GET", "/user/:name", func(ctx *fasthttp.RequestCtx) {
 		routed = true
-		want := Params{Param{"name", "gopher"}}
-		if !reflect.DeepEqual(ps, want) {
-			t.Fatalf("wrong wildcard values: want %v, got %v", want, ps)
+		want := string{"name", "gopher"}
+
+		if !ctx.UserValue(want[0]) == want[1] {
+			t.Fatalf("wrong wildcard values: want %v, got %v", want[0], want[1])
 		}
 		ctx.Success("foo/bar", []byte("success"))
 	})
@@ -87,25 +71,25 @@ func TestRouterAPI(t *testing.T) {
 	var get, head, options, post, put, patch, deleted bool
 
 	router := New()
-	router.GET("/GET", func(ctx *fasthttp.RequestCtx, _ Params) {
+	router.GET("/GET", func(ctx *fasthttp.RequestCtx) {
 		get = true
 	})
-	router.HEAD("/GET", func(ctx *fasthttp.RequestCtx, _ Params) {
+	router.HEAD("/GET", func(ctx *fasthttp.RequestCtx) {
 		head = true
 	})
-	router.OPTIONS("/GET", func(ctx *fasthttp.RequestCtx, _ Params) {
+	router.OPTIONS("/GET", func(ctx *fasthttp.RequestCtx) {
 		options = true
 	})
-	router.POST("/POST", func(ctx *fasthttp.RequestCtx, _ Params) {
+	router.POST("/POST", func(ctx *fasthttp.RequestCtx) {
 		post = true
 	})
-	router.PUT("/PUT", func(ctx *fasthttp.RequestCtx, _ Params) {
+	router.PUT("/PUT", func(ctx *fasthttp.RequestCtx) {
 		put = true
 	})
-	router.PATCH("/PATCH", func(ctx *fasthttp.RequestCtx, _ Params) {
+	router.PATCH("/PATCH", func(ctx *fasthttp.RequestCtx) {
 		patch = true
 	})
-	router.DELETE("/DELETE", func(ctx *fasthttp.RequestCtx, _ Params) {
+	router.DELETE("/DELETE", func(ctx *fasthttp.RequestCtx) {
 		deleted = true
 	})
 
@@ -245,13 +229,13 @@ func TestRouterChaining(t *testing.T) {
 	router1.NotFound = router2.Handler
 
 	fooHit := false
-	router1.POST("/foo", func(ctx *fasthttp.RequestCtx, _ Params) {
+	router1.POST("/foo", func(ctx *fasthttp.RequestCtx) {
 		fooHit = true
 		ctx.SetStatusCode(fasthttp.StatusOK)
 	})
 
 	barHit := false
-	router2.POST("/bar", func(ctx *fasthttp.RequestCtx, _ Params) {
+	router2.POST("/bar", func(ctx *fasthttp.RequestCtx) {
 		barHit = true
 		ctx.SetStatusCode(fasthttp.StatusOK)
 	})
@@ -329,7 +313,7 @@ func TestRouterChaining(t *testing.T) {
 func TestRouterOPTIONS(t *testing.T) {
 	// TODO: because fasthttp is not support OPTIONS method now,
 	// these test cases will be used in the future.
-	handlerFunc := func(_ *fasthttp.RequestCtx, _ Params) {}
+	handlerFunc := func(_ *fasthttp.RequestCtx) {}
 
 	router := New()
 	router.POST("/path", handlerFunc)
@@ -462,7 +446,7 @@ func TestRouterOPTIONS(t *testing.T) {
 
 	// custom handler
 	var custom bool
-	router.OPTIONS("/path", func(_ *fasthttp.RequestCtx, _ Params) {
+	router.OPTIONS("/path", func(_ *fasthttp.RequestCtx) {
 		custom = true
 	})
 
@@ -519,7 +503,7 @@ func TestRouterOPTIONS(t *testing.T) {
 }
 
 func TestRouterNotAllowed(t *testing.T) {
-	handlerFunc := func(_ *fasthttp.RequestCtx, _ Params) {}
+	handlerFunc := func(_ *fasthttp.RequestCtx) {}
 
 	router := New()
 	router.POST("/path", handlerFunc)
@@ -613,7 +597,7 @@ func TestRouterNotAllowed(t *testing.T) {
 }
 
 func TestRouterNotFound(t *testing.T) {
-	handlerFunc := func(_ *fasthttp.RequestCtx, _ Params) {}
+	handlerFunc := func(_ *fasthttp.RequestCtx) {}
 
 	router := New()
 	router.GET("/path", handlerFunc)
@@ -743,7 +727,7 @@ func TestRouterPanicHandler(t *testing.T) {
 		panicHandled = true
 	}
 
-	router.Handle("PUT", "/user/:name", func(_ *fasthttp.RequestCtx, _ Params) {
+	router.Handle("PUT", "/user/:name", func(_ *fasthttp.RequestCtx) {
 		panic("oops!")
 	})
 
@@ -780,15 +764,14 @@ func TestRouterPanicHandler(t *testing.T) {
 
 func TestRouterLookup(t *testing.T) {
 	routed := false
-	wantHandle := func(_ *fasthttp.RequestCtx, _ Params) {
+	wantHandle := func(_ *fasthttp.RequestCtx) {
 		routed = true
 	}
-	wantParams := Params{Param{"name", "gopher"}}
 
 	router := New()
 
 	// try empty router first
-	handle, _, tsr := router.Lookup("GET", "/nope")
+	handle, tsr := router.Lookup("GET", "/nope")
 	if handle != nil {
 		t.Fatalf("Got handle for unregistered pattern: %v", handle)
 	}
@@ -799,7 +782,7 @@ func TestRouterLookup(t *testing.T) {
 	// insert route and try again
 	router.GET("/user/:name", wantHandle)
 
-	handle, params, tsr := router.Lookup("GET", "/user/gopher")
+	handle, tsr = router.Lookup("GET", "/user/gopher")
 	if handle == nil {
 		t.Fatal("Got no handle!")
 	} else {
@@ -809,11 +792,7 @@ func TestRouterLookup(t *testing.T) {
 		}
 	}
 
-	if !reflect.DeepEqual(params, wantParams) {
-		t.Fatalf("Wrong parameter values: want %v, got %v", wantParams, params)
-	}
-
-	handle, _, tsr = router.Lookup("GET", "/user/gopher/")
+	handle, tsr = router.Lookup("GET", "/user/gopher/")
 	if handle != nil {
 		t.Fatalf("Got handle for unregistered pattern: %v", handle)
 	}
@@ -821,7 +800,7 @@ func TestRouterLookup(t *testing.T) {
 		t.Error("Got no TSR recommendation!")
 	}
 
-	handle, _, tsr = router.Lookup("GET", "/nope")
+	handle, tsr = router.Lookup("GET", "/nope")
 	if handle != nil {
 		t.Fatalf("Got handle for unregistered pattern: %v", handle)
 	}

--- a/tree.go
+++ b/tree.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+	"github.com/valyala/fasthttp"
 )
 
 func min(a, b int) int {
@@ -47,7 +48,7 @@ type node struct {
 	maxParams uint8
 	indices   string
 	children  []*node
-	handle    Handle
+	handle    fasthttp.RequestHandler
 	priority  uint32
 }
 
@@ -79,7 +80,7 @@ func (n *node) incrementChildPrio(pos int) int {
 
 // addRoute adds a node with the given handle to the path.
 // Not concurrency-safe!
-func (n *node) addRoute(path string, handle Handle) {
+func (n *node) addRoute(path string, handle fasthttp.RequestHandler) {
 	fullPath := path
 	n.priority++
 	numParams := countParams(path)
@@ -202,7 +203,7 @@ func (n *node) addRoute(path string, handle Handle) {
 	}
 }
 
-func (n *node) insertChild(numParams uint8, path, fullPath string, handle Handle) {
+func (n *node) insertChild(numParams uint8, path, fullPath string, handle fasthttp.RequestHandler) {
 	var offset int // already handled bytes of the path
 
 	// find prefix until first wildcard (beginning with ':'' or '*'')
@@ -320,7 +321,7 @@ func (n *node) insertChild(numParams uint8, path, fullPath string, handle Handle
 // If no handle can be found, a TSR (trailing slash redirect) recommendation is
 // made if a handle exists with an extra (without the) trailing slash for the
 // given path.
-func (n *node) getValue(path string) (handle Handle, p Params, tsr bool) {
+func (n *node) getValue(path string, ctx fasthttp.RequestCtx) (handle fasthttp.RequestHandler, tsr bool) {
 walk: // outer loop for walking the tree
 	for {
 		if len(path) > len(n.path) {
@@ -356,15 +357,7 @@ walk: // outer loop for walking the tree
 						end++
 					}
 
-					// save param value
-					if p == nil {
-						// lazy allocation
-						p = make(Params, 0, n.maxParams)
-					}
-					i := len(p)
-					p = p[:i+1] // expand slice within preallocated capacity
-					p[i].Key = n.path[1:]
-					p[i].Value = path[:end]
+					ctx.SetUserValue(n.path[1:], path[:end])
 
 					// we need to go deeper!
 					if end < len(path) {
@@ -392,15 +385,7 @@ walk: // outer loop for walking the tree
 
 				case catchAll:
 					// save param value
-					if p == nil {
-						// lazy allocation
-						p = make(Params, 0, n.maxParams)
-					}
-					i := len(p)
-					p = p[:i+1] // expand slice within preallocated capacity
-					p[i].Key = n.path[2:]
-					p[i].Value = path
-
+					ctx.SetUserValue(n.path[2:], path)
 					handle = n.handle
 					return
 
@@ -447,7 +432,7 @@ walk: // outer loop for walking the tree
 // It can optionally also fix trailing slashes.
 // It returns the case-corrected path and a bool indicating whether the lookup
 // was successful.
-func (n *node) findCaseInsensitivePath(path string, fixTrailingSlash bool) (ciPath []byte, found bool) {
+func (n *node) findCaseInsensitivePath(path string, fixTrailingSlash bool) ([]byte, bool) {
 	return n.findCaseInsensitivePathRec(
 		path,
 		strings.ToLower(path),

--- a/tree.go
+++ b/tree.go
@@ -321,7 +321,7 @@ func (n *node) insertChild(numParams uint8, path, fullPath string, handle fastht
 // If no handle can be found, a TSR (trailing slash redirect) recommendation is
 // made if a handle exists with an extra (without the) trailing slash for the
 // given path.
-func (n *node) getValue(path string, ctx fasthttp.RequestCtx) (handle fasthttp.RequestHandler, tsr bool) {
+func (n *node) getValue(path string, ctx *fasthttp.RequestCtx) (handle fasthttp.RequestHandler, tsr bool) {
 walk: // outer loop for walking the tree
 	for {
 		if len(path) > len(n.path) {


### PR DESCRIPTION
This PR uses: `func(ctx *fasthttp.RequestCtx)`
Instead of: `func(ctx *fasthttp.RequestCtx, ps fasthttprouter.Params)`

And

Replaces `Params` with `RequestCtx.UserValues`

So that: 

1. Chaining of other `fasthttp` based middleware functions is much easier.
2. Removes the only major memory allocation that is happening in `fasthttprouter/httprouter`


