### PR TITLE
Fix query string on trailing slash redirect

### DIFF
--- a/router.go
+++ b/router.go
@@ -314,6 +314,11 @@ func (r *Router) Handler(ctx *fasthttp.RequestCtx) {
 				} else {
 					uri = path + "/"
 				}
+				
+				if len(ctx.URI().QueryString()) > 0 {
+					uri += "?" + string(ctx.QueryArgs().QueryString())
+				}
+				
 				ctx.Redirect(uri, code)
 				return
 			}


### PR DESCRIPTION
This commit fixes query string lost on trailing slash redirect.

Example:
handler - ```router.POST("/v1/info/", myHandler)```
request - ```mysite.com/v1/info?id=1```
expected - ```HTTP 301 /v1/info/?id=1```
got - ```HTTP 301 /v1/info/```