### PR TITLE
Using original path in router

### DIFF
--- a/router.go
+++ b/router.go
@@ -293,7 +293,7 @@ func (r *Router) Handler(ctx *fasthttp.RequestCtx) {
 		defer r.recv(ctx)
 	}
 
-	path := string(ctx.Path())
+	path := string(ctx.URI().PathOriginal())
 	method := string(ctx.Method())
 	if root := r.trees[method]; root != nil {
 		if f, tsr := root.getValue(path, ctx); f != nil {

--- a/router_test.go
+++ b/router_test.go
@@ -617,7 +617,7 @@ func TestRouterNotFound(t *testing.T) {
 		{"/DIR/", 301},           // Fixed Case +/
 		{"/paTh/?name=foo", 301}, // Fixed Case With Params +/
 		{"/paTh?name=foo", 301},  // Fixed Case With Params +/
-		{"/../path", 200},        // CleanPath
+		{"/../path", 301},        // CleanPath
 		{"/nope", 404},           // NotFound
 	}
 


### PR DESCRIPTION
Router's Handler method is using ctx.Path() to get the path, which is already parsed (normalized) by fasthttp. As a result, router attributes like RedirectTrailingSlash and RedirectFixedPath will never be used, since the paths it gets are always fixed. Also, for example, requests to /path//info can never get to the intended handler (which handles request on path /path/:param/info), since the path are getting normalized to /path/info by fasthttp.